### PR TITLE
Fix memory leak

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
             SOI[1] = 0xD8;
             const CONTENT_LENGTH = 'content-length';
             const TYPE_JPEG = 'image/jpeg';
+            let image = document.getElementById('image');
 
             fetch(url)
             .then(response => {
@@ -68,7 +69,9 @@
                             // we're done reading the jpeg. Time to render it. 
                             else {
                                 // console.log("jpeg read with bytes : " + bytesRead);
-                                document.getElementById('image').src = URL.createObjectURL(new Blob([imageBuffer], {type: TYPE_JPEG}));
+                                let frame = URL.createObjectURL(new Blob([imageBuffer], {type: MJPEG.TYPE_JPEG})) 
+                                image.src = frame;
+                                URL.revokeObjectURL(frame)
                                 frames++;
                                 contentLength = 0;
                                 bytesRead = 0;


### PR DESCRIPTION
The code memory leaked a lot due to caching the stream. This patch fixes that by revoking the ObjectURL.
It also moves the querySelector outside the loop since the target does not change.
Tested on Firefox only.